### PR TITLE
Correct small typo in datepicker dcc documentation

### DIFF
--- a/tutorial/core_component_examples.py
+++ b/tutorial/core_component_examples.py
@@ -825,7 +825,7 @@ from datetime import datetime as dt
 
 dcc.DatePickerRange(
     is_RTL=True,
-    first_day_of_week=3,
+    first_day_of_week=2,
     start_date=dt(2017,6,21)
 )''', style=styles.code_container),
     html.Hr(),
@@ -1061,7 +1061,7 @@ from datetime import datetime as dt
 
 dcc.DatePickerSingle(
     is_RTL=True,
-    first_day_of_week=3,
+    first_day_of_week=2,
     date=dt(2017,6,21)
 )'''),
 


### PR DESCRIPTION
## Initial Problem
Documentation says `... Tuesday is the first day of the week.` when in fact, the output is actually "Wednesday". 

## Change
Thus, I changed `first_day_of_week=3` to `first_day_of_week=2` in the code examples to reflect correctly the documentation.

Hope this is the right branch to push to. If not, please scold accordingly. 

---

Post-merge checklist:

The master branch is auto-deployed to `dash.plot.ly`.
Once you have merged your PR, wait 5-10 minutes and check dash.plot.ly 
to verify that your changes have been made.

- [ ] I understand

If this PR documents a new feature of Dash:

- [ ] Comment on the original Dash issue with a link to the new docs.
- [ ] Reply to any community thread(s) asking for this feature.
